### PR TITLE
[Very Experimental] #derive[LuaTable]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ builtin-lua = ["cc"]
 libc = { version = "0.2" }
 failure = { git = "https://github.com/rust-lang-nursery/failure", version = "1.0" }
 compiletest_rs = { version = "0.3", optional = true }
+rlua-derive = { version = "0.0.1", path = "./rlua-derive", optional = true }
 
 [build-dependencies]
 cc = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,6 @@ criterion = "0.2.0"
 [[bench]]
 name = "benchmark"
 harness = false
+
+[workspace]
+members = ["rlua-derive"]

--- a/rlua-derive/Cargo.toml
+++ b/rlua-derive/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rlua-derive"
+version = "0.0.1"
+authors = ["kyren <catherine@chucklefish.org>", "kngwyu <yuji.kngw.80s.revive@gmail.com>"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "0.12"
+quote = "0.4"
+synstructure = {git = "https://github.com/nrxus/synstructure.git"}

--- a/rlua-derive/Cargo.toml
+++ b/rlua-derive/Cargo.toml
@@ -10,3 +10,6 @@ proc-macro = true
 syn = "0.12"
 quote = "0.4"
 synstructure = {git = "https://github.com/nrxus/synstructure.git"}
+
+[dev-dependencies]
+rlua = {path = "../", features = ["rlua-derive"]}

--- a/rlua-derive/Cargo.toml
+++ b/rlua-derive/Cargo.toml
@@ -9,7 +9,7 @@ proc-macro = true
 [dependencies]
 syn = "0.12"
 quote = "0.4"
-synstructure = {git = "https://github.com/nrxus/synstructure.git"}
+synstructure = {git = "https://github.com/mystor/synstructure.git"}
 
 [dev-dependencies]
 rlua = {path = "../", features = ["rlua-derive"]}

--- a/rlua-derive/examples/derive_usage.rs
+++ b/rlua-derive/examples/derive_usage.rs
@@ -1,0 +1,62 @@
+extern crate rlua;
+
+use rlua::*;
+
+fn derive_usage() -> Result<()> {
+    let lua = Lua::new();
+    #[derive(LuaTable, Debug)]
+    struct Vec2D(f64, f64);
+
+    let table = Vec2D(3.0, 4.0).into_table(&lua)?;
+    lua.globals().set("v2", table)?;
+    lua.exec::<()>(
+        r#"
+print(v2._0)
+print(v2._1)
+v2._0 = 100
+v2._1 = v2._0 * 2
+"#,
+        None,
+    )?;
+
+    let table = lua.globals().get("v2")?;
+    let v2 = Vec2D::from_table(table, &lua)?;
+    println!("{:?}", v2);
+
+    #[derive(LuaTable, Debug)]
+    struct Vec3D {
+        x: f64,
+        y: f64,
+        z: f64,
+    }
+    impl Vec3D {
+        fn new<T: Into<f64>>(x: T, y: T, z: T) -> Vec3D {
+            Vec3D {
+                x: x.into(),
+                y: y.into(),
+                z: z.into(),
+            }
+        }
+    }
+    let table = Vec3D::new(4, 5, 6).into_table(&lua)?;
+    lua.globals().set("v3", table)?;
+    lua.exec::<()>(
+        r#"
+print(v3.x)
+print(v3.y)
+print(v3.z)
+v3.x = 356
+v3.y = v3.x * 2
+v3.z = v3.y * 2
+"#,
+        None,
+    )?;
+    let table = lua.globals().get("v3")?;
+    let v3 = Vec3D::from_table(table, &lua)?;
+    println!("{:?}", v3);
+    Ok(())
+}
+
+fn main() {
+    derive_usage().unwrap();
+}

--- a/rlua-derive/src/lib.rs
+++ b/rlua-derive/src/lib.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate quote;
 #[macro_use]
 extern crate syn;
@@ -6,7 +5,7 @@ extern crate syn;
 extern crate synstructure;
 
 use std::slice;
-use syn::{Data, DeriveInput, Fields, Ident};
+use syn::{Data, DeriveInput, Fields};
 use synstructure::{BindingInfo, Structure};
 
 decl_derive!([LuaTable] => derive_lua_table);

--- a/rlua-derive/src/lib.rs
+++ b/rlua-derive/src/lib.rs
@@ -1,0 +1,225 @@
+#[macro_use]
+extern crate quote;
+#[macro_use]
+extern crate syn;
+#[macro_use]
+extern crate synstructure;
+
+use std::slice;
+use syn::{Data, DeriveInput, Fields, Ident};
+use synstructure::{BindingInfo, Structure};
+
+decl_derive!([LuaTable] => derive_lua_table);
+
+fn derive_lua_table(mut s: synstructure::Structure) -> quote::Tokens {
+    let struct_type = check_struct_type(s.ast());
+    let struct_name = s.ast().ident;
+
+    // get body for impl<'lua> IntoTable<'lua>
+    let into_body = match struct_type {
+        StructType::NormalStruct => s.each(|bind| {
+            let name = bind.ast().ident.unwrap();
+            quote! {
+                table.set(stringify!(#name), self.#name)?;
+            }
+        }),
+        StructType::TupleStruct => {
+            let mut count = 0;
+            s.each(|__bind| {
+                count += 1;
+                quote! {
+                    table.set(format!("_{}", #count - 1), self.0)?;
+                }
+            })
+        }
+    };
+
+    // get body for impl<'lua> FromTable<'lua>
+    let from_body = {
+        let bindings = get_binding_iter(&s);
+        let body = match struct_type {
+            StructType::NormalStruct => bindings.fold(quote::Tokens::new(), |mut t, bind| {
+                let name = bind.ast().ident.unwrap();
+                t.append_all(quote! {
+                    #name: table.get(stringify!(#name))?,
+                });
+                t
+            }),
+            StructType::TupleStruct => {
+                let mut count = 0;
+                bindings.fold(quote::Tokens::new(), |mut t, __bind| {
+                    count += 1;
+                    t.append_all(quote! {
+                        table.get(format!("_{}", #count - 1))?,
+                    });
+                    t
+                })
+            }
+        };
+        match struct_type {
+            StructType::NormalStruct => quote!( { #body }),
+            StructType::TupleStruct => quote!( ( #body )),
+        }
+    };
+    s.add_impl_generic(parse_quote!('lua));
+    let mut tokens = s.unbound_impl(
+        quote!(::rlua::IntoTable<'lua>),
+        quote! {
+            fn into_table(
+                self,
+                lua: &'lua Lua,
+            ) -> ::std::result::Result<::rlua::Table<'lua>, ::rlua::Error> {
+                let table = lua.create_table()?;
+                match self {
+                    #into_body
+                }
+                Ok(table)
+            }
+        },
+    );
+    tokens.append_all(s.unbound_impl(
+        quote!(::rlua::FromTable<'lua>),
+        quote!{
+            fn from_table(
+                table: Table<'lua>,
+                _lua: &'lua Lua,
+            ) -> ::std::result::Result<Self, ::rlua::Error> {
+                Ok(#struct_name #from_body)
+            }
+        },
+    ));
+    tokens
+}
+
+fn get_binding_iter<'a>(s: &'a Structure) -> slice::Iter<'a, BindingInfo<'a>> {
+    s.variants()
+        .into_iter()
+        .nth(0)
+        .unwrap()
+        .bindings()
+        .into_iter()
+}
+
+enum StructType {
+    TupleStruct,
+    NormalStruct,
+}
+
+fn check_struct_type(input: &DeriveInput) -> StructType {
+    let unsupported = |s| panic!("{} is not supported by #[derive(IntoTable)]!", s);
+    match input.data {
+        Data::Struct(ref data) => match data.fields {
+            Fields::Named(_) => StructType::NormalStruct,
+            Fields::Unnamed(_) => StructType::TupleStruct,
+            Fields::Unit => unsupported("Unit struct"),
+        },
+        Data::Enum(_) => unsupported("Enum"),
+        Data::Union(_) => unsupported("Union"),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn normal_struct() {
+        test_derive! {
+            derive_lua_table {
+                struct Point {
+                    x: i32,
+                    y: i32,
+                }
+            }
+            expands to {
+                #[allow(non_upper_case_globals)]
+                const _DERIVE_rlua_IntoTable_lua_FOR_Point: () = {
+                    impl<'lua> ::rlua::IntoTable<'lua> for Point {
+                        fn into_table(
+                            self,
+                            lua: &'lua Lua,
+                        ) -> ::std::result::Result<::rlua::Table<'lua>, ::rlua::Error> {
+                            let table = lua.create_table()?;
+                            match self {
+                                Point {
+                                    x: ref __binding_0,
+                                    y: ref __binding_1,
+                                } => {
+                                    {
+                                        table.set(stringify!(x), self.x)?;
+                                    }
+                                    {
+                                        table.set(stringify!(y), self.y)?;
+                                    }
+                                }
+                            }
+                            Ok(table)
+                        }
+                    }
+                };
+                #[allow(non_upper_case_globals)]
+                const _DERIVE_rlua_FromTable_lua_FOR_Point: () = {
+                    impl<'lua> ::rlua::FromTable<'lua> for Point {
+                        fn from_table(
+                            table: Table<'lua>,
+                            _lua: &'lua Lua,
+                        ) -> ::std::result::Result<Self, ::rlua::Error> {
+                              Ok(Point {
+                                  x: table.get(stringify!(x))?,
+                                  y: table.get(stringify!(y))?,
+                              })
+                        }
+                    }
+                };
+            }
+            no_build
+        }
+    }
+
+    #[test]
+    fn tuple_struct() {
+        test_derive! {
+            derive_lua_table {
+                struct Point(i32, i32);
+            }
+            expands to {
+                #[allow(non_upper_case_globals)]
+                const _DERIVE_rlua_IntoTable_lua_FOR_Point: () = {
+                    impl<'lua> ::rlua::IntoTable<'lua> for Point {
+                        fn into_table(
+                            self,
+                            lua: &'lua Lua,
+                        ) -> ::std::result::Result<::rlua::Table<'lua>, ::rlua::Error> {
+                            let table = lua.create_table()?;
+                            match self {
+                                Point(ref __binding_0 , ref __binding_1, ) => {
+                                    {
+                                        table.set(format!("_{}", 1i32 - 1), self.0)?;
+                                    }
+                                    {
+                                        table.set(format!("_{}", 2i32 - 1), self.0)?;
+                                    }
+                                }
+                            }
+                            Ok(table)
+                        }
+                    }
+                };
+                #[allow(non_upper_case_globals)]
+                const _DERIVE_rlua_FromTable_lua_FOR_Point: () = {
+                    impl<'lua> ::rlua::FromTable<'lua> for Point {
+                        fn from_table(
+                            table: Table<'lua>,
+                            _lua: &'lua Lua,
+                        ) -> ::std::result::Result<Self, ::rlua::Error> {
+                            Ok(Point(
+                                table.get(format!("_{}", 1i32 - 1))?,
+                                table.get(format!("_{}", 2i32 - 1))?,
+                            ))
+                        }
+                    }
+                };
+            }
+            no_build
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,3 +77,16 @@ pub use lua::Lua;
 pub use scope::Scope;
 
 pub mod prelude;
+
+#[cfg(feature = "rlua-derive")]
+#[doc(hidden)]
+pub use table::{FromTable, IntoTable};
+
+#[cfg(feature = "rlua-derive")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate rlua_derive;
+
+#[cfg(feature = "rlua-derive")]
+#[doc(hidden)]
+pub use rlua_derive::*;

--- a/src/table.rs
+++ b/src/table.rs
@@ -451,3 +451,16 @@ where
         }
     }
 }
+
+/// Experimental API for #[derive(IntoTable)]
+#[cfg(feature = "rlua-derive")]
+#[doc(hidden)]
+pub trait IntoTable<'lua> {
+    fn into_table(self, lua: &'lua ::lua::Lua) -> Result<Table<'lua>>;
+}
+
+#[cfg(feature = "rlua-derive")]
+#[doc(hidden)]
+pub trait FromTable<'lua>: Sized {
+    fn from_table(table: Table<'lua>, lua: &'lua ::lua::Lua) -> Result<Self>;
+}


### PR DESCRIPTION
This PR proposes `#[derive(LuaTable)]` syntax.
This attribute implements new `FromTable` and `IntoTable` trait.
We can convert struct with `#[derive(LuaTable)` into `Table` by `into_table` method, and vice versa(by `from_table` method.
See example for usage.

Though there are many problems (e.g. integration with `UserData` type), I think this is useful.