### PR TITLE
Impl UserData for `Arc<Mutex<T>> where T: UserData`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ pkg-config = { version = "0.3.11", optional = true }
 rustyline = "6.0"
 criterion = "0.3.0"
 compiletest_rs = { version = "0.4", features = ["stable"] }
+crossbeam = "0.8.0"
 
 [[bench]]
 name = "benchmark"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ mod table;
 mod thread;
 mod types;
 mod userdata;
+mod userdata_wrappers;
 mod util;
 mod value;
 

--- a/src/userdata_wrappers.rs
+++ b/src/userdata_wrappers.rs
@@ -1,14 +1,12 @@
 //! Implements UserData for a number of helpful Rust std types.
 
 use std::{
-    ptr,
+    mem, ptr,
     sync::{Arc, Mutex},
 };
 
 use crate::{
-    ffi,
-    util::{assert_stack, StackGuard},
-    Function, MetaMethod, MultiValue, Table, UserData, UserDataMethods,
+    ffi, Context, Function, MetaMethod, MultiValue, Result, Table, UserData, UserDataMethods, Value,
 };
 
 const ALL_METAMETHOD_KEYS: &[MetaMethod] = &[
@@ -41,66 +39,61 @@ const ALL_METAMETHOD_KEYS: &[MetaMethod] = &[
 
 /// `Arc<Mutex<T>>` will act more or less like the original `T`.
 /// It does this by registering metamethods that, when called, just act on the original `T`.
-impl<T: 'static + Send + UserData> UserData for Arc<Mutex<T>> {
+///
+/// The `Default` trait bound is currently required, but may not be required in the future.
+/// It's only use is to prevent a double-drop error.
+/// The default `#[derive(Default)]` implementation should be enough.
+///
+/// See the source code for more details.
+impl<T: 'static + Send + UserData + Default> UserData for Arc<Mutex<T>> {
     fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
         // This must implement all the same metamethods as T does.
         for mm_key in ALL_METAMETHOD_KEYS.iter() {
-            methods.add_meta_method(*mm_key, move |ctx, this, args: MultiValue| {
-                // This code copied from Table::get_metatable
-                unsafe {
-                    if let Some(metatable) = {
-                        // no clue what this does?
-                        let _sg = StackGuard::new(ctx.state);
-                        assert_stack(ctx.state, 1);
+            methods.add_meta_method(
+                *mm_key,
+                move |ctx, this, args: MultiValue| -> Result<MultiValue> {
+                    unsafe {
+                        // Get the ID of T's metatable
+                        let mt_id = ctx.userdata_metatable::<T>()?;
+                        // Push the (hopefully) metatable onto the stack
+                        let pushed_type = ffi::lua_rawgeti(
+                            ctx.state,
+                            ffi::LUA_REGISTRYINDEX,
+                            mt_id as ffi::lua_Integer,
+                        );
+                        assert_eq!(pushed_type, ffi::LUA_TTABLE);
 
-                        // What I need to do is: push the pointed-to value
-                        // of the mutex to Lua's stack.
-                        // This will require unsafe code.
-                        let guard = this.lock().unwrap();
-                        // Great, this is now the only thing that can access this data.
-                        // This is safe since we will fix up the mutex before we go.
-                        let tmp: T = ptr::read(&*guard as *const T);
-                        let tmp_as_userdata = ctx.create_userdata(tmp)?;
-                        // push the lref
-                        ctx.push_ref(&tmp_as_userdata.0);
-                        // Try and get its metatable
-                        let mt = if ffi::lua_getmetatable(ctx.state, -1) == 0 {
-                            None
-                        } else {
-                            let table = Table(ctx.pop_ref());
-                            Some(table)
-                        };
-                        // now put the data back in the guard
-                        let tmp_borrowed = tmp_as_userdata.borrow_mut::<T>()?;
-                        let tmp_recovered = ptr::read(&*tmp_borrowed as *const T);
-                        // presenting the worst Rust code you've ever seen this side of winapi
-                        ptr::write(&*guard as *const T as *mut T, tmp_recovered);
-                        // and as `tmp_as_userdata` is dropped here, all is well.
-                        mt
-                    } {
-                        // This userdata has a metatable!
+                        // Pop the metatable off the stack
+                        let metatable = Table(ctx.pop_ref());
+
                         // Let's go call that metamethod
                         let method: Function =
                             metatable.raw_get(std::str::from_utf8(mm_key.name()).unwrap())?;
-                        // Do more unsafe shenanigans.
+                        // Copy the T out of the mutex bitwise.
                         // This is so the metamethod call can mutate the T,
                         // and it's safely written back at the end.
-                        let guard = this.lock().unwrap();
+                        let mut guard = this.lock().unwrap();
+                        // Entering the NO PANIC ZONE
                         let tmp: T = ptr::read(&*guard as *const T);
                         let tmp_as_userdata = ctx.create_userdata(tmp)?;
                         // The clone here is sound as AnyUserData just holds a reference
-                        let call_res = method.call((tmp_as_userdata.clone(), args))?;
-                        let tmp_borrowed = tmp_as_userdata.borrow_mut::<T>()?;
-                        let tmp_recovered = ptr::read(&*tmp_borrowed as *const T);
-                        ptr::write(&*guard as *const T as *mut T, tmp_recovered);
+                        let all_args = (tmp_as_userdata.clone(), args);
+                        let call_res = method.call(all_args)?;
+                        // the function call might have mutated the `this` value...
+                        // let's get it.
+                        // recover the address of the userdata out of the stack
+                        let mut tmp_borrow = tmp_as_userdata.borrow_mut::<T>()?;
+                        // We can't let `tmp_as_userdata` keep existing, because when
+                        // it is dropped, it will also drop the original T.
+                        // So we fill it with a default.
+                        let recovered_tmp = mem::take::<T>(&mut tmp_borrow);
+                        // Write the recovered value without dropping the T in the mutex
+                        ptr::write(&mut *guard as *mut T, recovered_tmp);
+
                         Ok(call_res)
-                    } else {
-                        // There's no metatable to get a metamethod from
-                        // Return nil.
-                        Ok(MultiValue::new())
                     }
-                }
-            });
+                },
+            );
         }
     }
 }

--- a/src/userdata_wrappers.rs
+++ b/src/userdata_wrappers.rs
@@ -1,0 +1,106 @@
+//! Implements UserData for a number of helpful Rust std types.
+
+use std::{
+    ptr,
+    sync::{Arc, Mutex},
+};
+
+use crate::{
+    ffi,
+    util::{assert_stack, StackGuard},
+    Function, MetaMethod, MultiValue, Table, UserData, UserDataMethods,
+};
+
+const ALL_METAMETHOD_KEYS: &[MetaMethod] = &[
+    MetaMethod::Add,
+    MetaMethod::BAnd,
+    MetaMethod::BAnd,
+    MetaMethod::BNot,
+    MetaMethod::BOr,
+    MetaMethod::BXor,
+    MetaMethod::Call,
+    MetaMethod::Concat,
+    MetaMethod::Div,
+    MetaMethod::Eq,
+    MetaMethod::IDiv,
+    MetaMethod::Index,
+    MetaMethod::Le,
+    MetaMethod::Len,
+    MetaMethod::Lt,
+    MetaMethod::Mod,
+    MetaMethod::Mul,
+    MetaMethod::NewIndex,
+    MetaMethod::Pairs,
+    MetaMethod::Pow,
+    MetaMethod::Shl,
+    MetaMethod::Shr,
+    MetaMethod::Sub,
+    MetaMethod::ToString,
+    MetaMethod::Unm,
+];
+
+/// `Arc<Mutex<T>>` will act more or less like the original `T`.
+/// It does this by registering metamethods that, when called, just act on the original `T`.
+impl<T: 'static + Send + UserData> UserData for Arc<Mutex<T>> {
+    fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        // This must implement all the same metamethods as T does.
+        for mm_key in ALL_METAMETHOD_KEYS.iter() {
+            methods.add_meta_method(*mm_key, move |ctx, this, args: MultiValue| {
+                // This code copied from Table::get_metatable
+                unsafe {
+                    if let Some(metatable) = {
+                        // no clue what this does?
+                        let _sg = StackGuard::new(ctx.state);
+                        assert_stack(ctx.state, 1);
+
+                        // What I need to do is: push the pointed-to value
+                        // of the mutex to Lua's stack.
+                        // This will require unsafe code.
+                        let guard = this.lock().unwrap();
+                        // Great, this is now the only thing that can access this data.
+                        // This is safe since we will fix up the mutex before we go.
+                        let tmp: T = ptr::read(&*guard as *const T);
+                        let tmp_as_userdata = ctx.create_userdata(tmp)?;
+                        // push the lref
+                        ctx.push_ref(&tmp_as_userdata.0);
+                        // Try and get its metatable
+                        let mt = if ffi::lua_getmetatable(ctx.state, -1) == 0 {
+                            None
+                        } else {
+                            let table = Table(ctx.pop_ref());
+                            Some(table)
+                        };
+                        // now put the data back in the guard
+                        let tmp_borrowed = tmp_as_userdata.borrow_mut::<T>()?;
+                        let tmp_recovered = ptr::read(&*tmp_borrowed as *const T);
+                        // presenting the worst Rust code you've ever seen this side of winapi
+                        ptr::write(&*guard as *const T as *mut T, tmp_recovered);
+                        // and as `tmp_as_userdata` is dropped here, all is well.
+                        mt
+                    } {
+                        // This userdata has a metatable!
+                        // Let's go call that metamethod
+                        let method: Function =
+                            metatable.raw_get(std::str::from_utf8(mm_key.name()).unwrap())?;
+                        // Do more unsafe shenanigans.
+                        // This is so the metamethod call can mutate the T,
+                        // and it's safely written back at the end.
+                        let guard = this.lock().unwrap();
+                        let tmp: T = ptr::read(&*guard as *const T);
+                        let tmp_as_userdata = ctx.create_userdata(tmp)?;
+                        // The clone here is sound as AnyUserData just holds a reference
+                        let call_res = method.call((tmp_as_userdata.clone(), args))?;
+                        let tmp_borrowed = tmp_as_userdata.borrow_mut::<T>()?;
+                        let tmp_recovered = ptr::read(&*tmp_borrowed as *const T);
+                        ptr::write(&*guard as *const T as *mut T, tmp_recovered);
+                        Ok(call_res)
+                    } else {
+                        // There's no metatable to get a metamethod from
+                        // Return nil.
+                        Ok(MultiValue::new())
+                    }
+                }
+            });
+        }
+    }
+}

--- a/tests/userdata_wrappers.rs
+++ b/tests/userdata_wrappers.rs
@@ -1,24 +1,30 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    cell::Cell,
+    sync::{Arc, Mutex},
+};
 
 use rlua::{Lua, MetaMethod, Result, Table, UserData, UserDataMethods};
+
+use crossbeam::atomic::AtomicCell;
 
 /// Test if a table of clones of an original Arc<Mutex<T>>
 /// get updated when the original does.
 #[test]
 fn arc_mux_many_to_one() {
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Foo(i32);
     impl UserData for Foo {
         fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
             methods.add_meta_method(MetaMethod::ToString, |_ctx, this, ()| {
-                Ok(this.0.to_string())
+                let out = this.0.to_string();
+                println!("to string called: {}", &out);
+                Ok(out)
             });
         }
     }
 
     let original = Arc::new(Mutex::new(Foo(1)));
     let clones = (0..10).map(|_| original.clone()).collect::<Vec<_>>();
-    println!("{:?}", clones);
 
     let lua = Lua::new();
     lua.context(|ctx| -> Result<()> {
@@ -36,9 +42,6 @@ fn arc_mux_many_to_one() {
 
         ctx.load(
             r#"
-            print("clones", clones)
-            print(clones[1])
-
             output = ""
             for _idx, val in ipairs(clones) do
                 -- yes this is bad practice to concat strings like this...
@@ -53,7 +56,9 @@ fn arc_mux_many_to_one() {
             "1 1 1 1 1 1 1 1 1 1 ".to_string()
         );
 
-        *original.lock().unwrap() = Foo(5);
+        let mut lock = original.lock().unwrap();
+        *lock = Foo(5);
+        drop(lock);
 
         ctx.load(
             r#"
@@ -81,7 +86,7 @@ fn arc_mux_many_to_one() {
 /// Also drops the original Arc<Mutex> (just to make sure).
 #[test]
 fn arc_mux_many_to_many() {
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct Foo(i32);
     impl UserData for Foo {
         fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
@@ -139,4 +144,79 @@ fn arc_mux_many_to_many() {
         Ok(())
     })
     .unwrap();
+}
+
+/// Make sure nothing gets dropped twice
+#[test]
+fn drop_twice() {
+    #[derive(Debug)]
+    struct DropTracker {
+        id: String,
+        drop_tracker: Arc<Mutex<String>>,
+    };
+
+    impl Drop for DropTracker {
+        fn drop(&mut self) {
+            // Push this ID to the drop tracker
+            self.drop_tracker.lock().unwrap().push_str(&self.id);
+        }
+    }
+
+    impl UserData for DropTracker {
+        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+            methods.add_meta_method_mut(MetaMethod::Call, |_ctx, _this, ()| {
+                // no-op
+                Ok(())
+            });
+        }
+    }
+
+    impl Default for DropTracker {
+        fn default() -> Self {
+            Self {
+                id: String::from("default"),
+                drop_tracker: Default::default(),
+            }
+        }
+    }
+
+    let drop_tracker = Arc::new(Mutex::new(String::new()));
+    let lua = Lua::new();
+    lua.context(|ctx| {
+        let test_size = 1000;
+        let globals = ctx.globals();
+
+        let original = Arc::new(Mutex::new(DropTracker {
+            id: String::from("original"),
+            drop_tracker: drop_tracker.clone(),
+        }));
+        let clones = ctx
+            .create_table_from((0..test_size).map(|idx| (idx + 1, original.clone())))
+            .unwrap();
+        globals.set("clones", clones).unwrap();
+
+        ctx.load(
+            r#"
+            for _idx, clone in ipairs(clones) do
+                clone()
+            end
+        "#,
+        )
+        .exec()
+        .unwrap();
+
+        // We still haven't dropped anything yet
+        assert_eq!(*drop_tracker.lock().unwrap(), "");
+        // Drop the original wrapper
+        drop(original);
+        // still haven't dropped the real value
+        assert_eq!(*drop_tracker.lock().unwrap(), "");
+    });
+
+    // still hasn't been dropped!
+    assert_eq!(*drop_tracker.lock().unwrap(), "");
+
+    // And *now* it has been dropped
+    drop(lua);
+    assert_eq!(*drop_tracker.lock().unwrap(), "original");
 }

--- a/tests/userdata_wrappers.rs
+++ b/tests/userdata_wrappers.rs
@@ -1,0 +1,142 @@
+use std::sync::{Arc, Mutex};
+
+use rlua::{Lua, MetaMethod, Result, Table, UserData, UserDataMethods};
+
+/// Test if a table of clones of an original Arc<Mutex<T>>
+/// get updated when the original does.
+#[test]
+fn arc_mux_many_to_one() {
+    #[derive(Debug)]
+    struct Foo(i32);
+    impl UserData for Foo {
+        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+            methods.add_meta_method(MetaMethod::ToString, |_ctx, this, ()| {
+                Ok(this.0.to_string())
+            });
+        }
+    }
+
+    let original = Arc::new(Mutex::new(Foo(1)));
+    let clones = (0..10).map(|_| original.clone()).collect::<Vec<_>>();
+    println!("{:?}", clones);
+
+    let lua = Lua::new();
+    lua.context(|ctx| -> Result<()> {
+        let globals = ctx.globals();
+
+        let clones_table = ctx
+            .create_table_from(
+                clones
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, val)| (idx + 1, val)),
+            )
+            .unwrap();
+        globals.set("clones", clones_table).unwrap();
+
+        ctx.load(
+            r#"
+            print("clones", clones)
+            print(clones[1])
+
+            output = ""
+            for _idx, val in ipairs(clones) do
+                -- yes this is bad practice to concat strings like this...
+                output = output .. tostring(val) .. " "
+            end
+        "#,
+        )
+        .exec()
+        .unwrap();
+        assert_eq!(
+            globals.get::<_, String>("output").unwrap(),
+            "1 1 1 1 1 1 1 1 1 1 ".to_string()
+        );
+
+        *original.lock().unwrap() = Foo(5);
+
+        ctx.load(
+            r#"
+            output = ""
+            for _idx, val in ipairs(clones) do
+                output = output .. tostring(val) .. " "
+            end
+        "#,
+        )
+        .exec()
+        .unwrap();
+        assert_eq!(
+            globals.get::<_, String>("output").unwrap(),
+            "5 5 5 5 5 5 5 5 5 5 ".to_string()
+        );
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+/// Test if a set of Arc<Mutex<T>>s are all updated
+/// when any of them is updated.
+///
+/// Also drops the original Arc<Mutex> (just to make sure).
+#[test]
+fn arc_mux_many_to_many() {
+    #[derive(Debug)]
+    struct Foo(i32);
+    impl UserData for Foo {
+        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+            // Please never do this in an actual library
+            methods.add_meta_method_mut(MetaMethod::Call, |_ctx, this, ()| {
+                this.0 += 1;
+                Ok(this.0)
+            });
+        }
+    }
+
+    let lua = Lua::new();
+    lua.context(|ctx| -> Result<()> {
+        let globals = ctx.globals();
+
+        // how high to count to
+        let test_size = 10_000;
+        // length of the test vec
+        let test_length = 1_000;
+        globals.set("test_size", test_size).unwrap();
+        globals.set("test_length", test_length).unwrap();
+
+        let foo = Arc::new(Mutex::new(Foo(0)));
+        let clones = ctx
+            .create_table_from((0..test_length).map(|idx| (idx + 1, foo.clone())))
+            .unwrap();
+        globals.set("clones", clones).unwrap();
+
+        drop(foo);
+
+        ctx.load(
+            r#"
+            for i = 1,test_size do
+                local idx = math.random(1, test_length)
+                assert(clones[idx]() == i)
+            end
+        "#,
+        )
+        .exec()
+        .unwrap();
+
+        let processed_clones: Table = globals.get("clones").unwrap();
+        for idx in 1..=test_length {
+            assert_eq!(
+                processed_clones
+                    .get::<_, Arc<Mutex<Foo>>>(idx)
+                    .unwrap()
+                    .lock()
+                    .unwrap()
+                    .0,
+                test_size
+            );
+        }
+
+        Ok(())
+    })
+    .unwrap();
+}


### PR DESCRIPTION
I'm currently writing a crate so you can `#[derive(UserData)]` on structs, and access their fields from Lua. However, I kept running into borrowing issues. The easiest way to fix those is to use an Arc<Mutex<T>>, but I can't impl UserData for Arc<Mutex<T>> due to the orphan rule. So, I made this fork.

I've included two tests, both of which seem sound. I don't doubt there's still some bugs in the implementation though... There's a lot of `unsafe` code.

The implementation registers every single metamethod, and in the callback, fetches the pointed-to value's metatable, gets the method out of it, and calls it on the pointed-to value. This means, to the Lua user, there should be little difference between using a T and an Arc<Mutex<T>> unless they are doing a lot of `getmetatable`s. The `unsafe` code is mostly `ptr::read` and `ptr::write`, used to copy values out of references and put them back afterwards (aside from the normal unsafety present in the backend).

It currently does *not* overwrite the Metatable method specially.